### PR TITLE
Ability to override scope per serializer so that we can add in any optimizations

### DIFF
--- a/lib/restpack_serializer/options.rb
+++ b/lib/restpack_serializer/options.rb
@@ -17,10 +17,8 @@ module RestPack::Serializer
 
       if serializer.respond_to?(:scope)
         @scope = serializer.send(:scope, scope || model_class.send(:all), context)
-      elsif scope
-        @scope = scope
       else
-        @scope = model_class.send(:all)
+        @scope = scope || model_class.send(:all)
       end
 
       @context = context

--- a/lib/restpack_serializer/options.rb
+++ b/lib/restpack_serializer/options.rb
@@ -14,7 +14,15 @@ module RestPack::Serializer
       @sorting = sorting_from_params(params, serializer)
       @serializer = serializer
       @model_class = serializer.model_class
-      @scope = scope || model_class.send(:all)
+
+      if serializer.respond_to?(:scope)
+        @scope = serializer.send(:scope, scope || model_class.send(:all), context)
+      elsif scope
+        @scope = scope
+      else
+        @scope = model_class.send(:all)
+      end
+
       @context = context
       @include_links = true
     end

--- a/lib/restpack_serializer/serializable/paging.rb
+++ b/lib/restpack_serializer/serializable/paging.rb
@@ -6,14 +6,13 @@ module RestPack::Serializer::Paging
       page_with_options RestPack::Serializer::Options.new(self, params, scope, context)
     end
 
-    def page_with_options(options)
+    def page_with_options(options, include_meta = true)
       page = options.scope_with_filters.page(options.page).per(options.page_size)
       page = page.reorder(options.sorting) if options.sorting.any?
 
       result = RestPack::Serializer::Result.new
       result.resources[self.key] = serialize_page(page, options)
-      result.meta[self.key] = serialize_meta(page, options)
-
+      result.meta[self.key] = serialize_meta(page, options) if include_meta
       if options.include_links
         result.links = self.links
         Array(RestPack::Serializer::Factory.create(*options.include)).each do |serializer|

--- a/lib/restpack_serializer/serializable/side_load_data_builder.rb
+++ b/lib/restpack_serializer/serializable/side_load_data_builder.rb
@@ -52,7 +52,7 @@ module RestPack
         options.page_size=1000 # pull all side loads in
         yield options
         options.include_links = false
-        serializer_class.page_with_options(options)
+        serializer_class.page_with_options(options, false)
       end
     end
   end

--- a/lib/restpack_serializer/serializable/side_loading.rb
+++ b/lib/restpack_serializer/serializable/side_loading.rb
@@ -60,7 +60,7 @@ module RestPack::Serializer::SideLoading
       builder = RestPack::Serializer::SideLoadDataBuilder.new(association,
                                                               models,
                                                               serializer)
-      builder.send("side_load_#{association.macro}")
+      builder.send("side_load_#{association.macro}", options)
     end
 
     def supported_association?(association_macro)


### PR DESCRIPTION
This allows us to create a scope class method on the serializer to customize the scope being passed through.

```
class ProjectSerializer < ApplicationSerializer
  include RestPack::Serializer

  def self.scope(scope, context)
    scope = scope.include(:reward_levels)
    scope
  end
end
```

Secondly, generating meta has been disabled for any has_many\* relationships since I don't believe it's used anywhere and it led to the extra count queries.
