### PR TITLE
Disabling the pluck of ids for has_many relationships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 tmp
 /coverage
 Gemfile.lock
+/.idea

--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -115,7 +115,10 @@ module RestPack
         when association.macro == :belongs_to
           model.send(association.foreign_key).try(:to_s)
         when association.macro.to_s.match(/has_/)
-          if context[:include_has_many_links]
+          if context[:include_has_many_links] || association.macro.to_s == "has_and_belongs_to_many"
+            if association.macro.to_s == "has_and_belongs_to_many"
+              p "#{association.name}: has_and_belongs_to_many"
+            end
             if model.send(association.name).loaded?
               model.send(association.name).collect { |associated| associated.id.to_s }
             else

--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -116,9 +116,6 @@ module RestPack
           model.send(association.foreign_key).try(:to_s)
         when association.macro.to_s.match(/has_/)
           if context[:include_has_many_links] || association.macro.to_s == "has_and_belongs_to_many"
-            if association.macro.to_s == "has_and_belongs_to_many"
-              p "#{association.name}: has_and_belongs_to_many"
-            end
             if model.send(association.name).loaded?
               model.send(association.name).collect { |associated| associated.id.to_s }
             else

--- a/lib/restpack_serializer/serializable.rb
+++ b/lib/restpack_serializer/serializable.rb
@@ -114,12 +114,12 @@ module RestPack
         links_value = case
         when association.macro == :belongs_to
           model.send(association.foreign_key).try(:to_s)
-        when association.macro.to_s.match(/has_/)
-          if model.send(association.name).loaded?
-            model.send(association.name).collect { |associated| associated.id.to_s }
-          else
-            model.send(association.name).pluck(:id).map(&:to_s)
-          end
+        # when association.macro.to_s.match(/has_/)
+        #   if model.send(association.name).loaded?
+        #     model.send(association.name).collect { |associated| associated.id.to_s }
+        #   else
+        #     model.send(association.name).pluck(:id).map(&:to_s)
+        #   end
         end
         unless links_value.blank?
           data[:links][association.name.to_sym] = links_value

--- a/lib/restpack_serializer/serializable/side_loading.rb
+++ b/lib/restpack_serializer/serializable/side_loading.rb
@@ -70,7 +70,7 @@ module RestPack::Serializer::SideLoading
 
     def association_from_include(include)
       raise_invalid_include(include) unless can_include?(include)
-      possible_relations = [include.to_s.singularize.to_sym, include]
+      possible_relations = [include, include.to_s.singularize.to_sym]
       select_association_from_possibles(possible_relations)
     end
 

--- a/lib/restpack_serializer/version.rb
+++ b/lib/restpack_serializer/version.rb
@@ -1,5 +1,5 @@
 module RestPack
   module Serializer
-    VERSION = '0.6.7'
+    VERSION = '0.6.8'
   end
 end

--- a/restpack_serializer.gemspec
+++ b/restpack_serializer.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activesupport', ['>= 4.0.3', '< 6.0']
   gem.add_dependency 'activerecord', ['>= 4.0.3', '< 6.0']
   gem.add_dependency 'kaminari', '~> 0.17.0'
+  gem.add_dependency 'kaminari-mongoid', '~> 0.1'
 
   gem.add_development_dependency 'restpack_gem', '~> 0.0.9'
   gem.add_development_dependency 'rake', '~> 11.3'

--- a/restpack_serializer.gemspec
+++ b/restpack_serializer.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'activesupport', ['>= 4.0.3', '< 5.0']
-  gem.add_dependency 'activerecord', ['>= 4.0.3', '< 5.0']
-  gem.add_dependency 'kaminari', '~> 0.16.1'
+  gem.add_dependency 'activesupport', ['>= 4.0.3', '< 6.0']
+  gem.add_dependency 'activerecord', ['>= 4.0.3', '< 6.0']
+  gem.add_dependency 'kaminari', '~> 0.17.0'
 
   gem.add_development_dependency 'restpack_gem', '~> 0.0.9'
   gem.add_development_dependency 'rake', '~> 11.1.2'

--- a/restpack_serializer.gemspec
+++ b/restpack_serializer.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'kaminari', '~> 0.17.0'
 
   gem.add_development_dependency 'restpack_gem', '~> 0.0.9'
-  gem.add_development_dependency 'rake', '~> 11.1.2'
-  gem.add_development_dependency 'guard-rspec', '~> 4.6.4'
-  gem.add_development_dependency 'factory_girl', '~> 4.7.0'
-  gem.add_development_dependency 'sqlite3', '~> 1.3.7'
-  gem.add_development_dependency 'database_cleaner', '~> 1.5.3'
+  gem.add_development_dependency 'rake', '~> 11.3'
+  gem.add_development_dependency 'guard-rspec', '~> 4.7'
+  gem.add_development_dependency 'factory_girl', '~> 4.7'
+  gem.add_development_dependency 'sqlite3', '~> 1.3'
+  gem.add_development_dependency 'database_cleaner', '~> 1.5'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'bump'
-  gem.add_development_dependency 'protected_attributes', '~> 1.1.3'
+  gem.add_development_dependency 'protected_attributes_continued', '~> 1.2'
 end

--- a/spec/factory/factory_spec.rb
+++ b/spec/factory/factory_spec.rb
@@ -5,45 +5,52 @@ describe RestPack::Serializer::Factory do
 
   describe "single-word" do
     it "creates by string" do
-      factory.create("Song").should be_an_instance_of(MyApp::SongSerializer)
+      expect(factory.create("Song")).to be_an_instance_of(MyApp::SongSerializer)
     end
+
     it "creates by lowercase string" do
-      factory.create("song").should be_an_instance_of(MyApp::SongSerializer)
+      expect(factory.create("song")).to be_an_instance_of(MyApp::SongSerializer)
     end
+
     it "creates by lowercase plural string" do
-      factory.create("songs").should be_an_instance_of(MyApp::SongSerializer)
+      expect(factory.create("songs")).to be_an_instance_of(MyApp::SongSerializer)
     end
+
     it "creates by symbol" do
-      factory.create(:song).should be_an_instance_of(MyApp::SongSerializer)
+      expect(factory.create(:song)).to be_an_instance_of(MyApp::SongSerializer)
     end
+
     it "creates by class" do
-      factory.create(MyApp::Song).should be_an_instance_of(MyApp::SongSerializer)
+      expect(factory.create(MyApp::Song)).to be_an_instance_of(MyApp::SongSerializer)
     end
 
     it "creates multiple with Array" do
       serializers = factory.create("Song", "artists", :album)
-      serializers[0].should be_an_instance_of(MyApp::SongSerializer)
-      serializers[1].should be_an_instance_of(MyApp::ArtistSerializer)
-      serializers[2].should be_an_instance_of(MyApp::AlbumSerializer)
+      expect(serializers[0]).to be_an_instance_of(MyApp::SongSerializer)
+      expect(serializers[1]).to be_an_instance_of(MyApp::ArtistSerializer)
+      expect(serializers[2]).to be_an_instance_of(MyApp::AlbumSerializer)
     end
   end
 
   describe "multi-word" do
     it "creates multi-word string" do
-      factory.create("AlbumReview").should be_an_instance_of(MyApp::AlbumReviewSerializer)
+      expect(factory.create("AlbumReview")).to be_an_instance_of(MyApp::AlbumReviewSerializer)
     end
+
     it "creates multi-word lowercase string" do
-      factory.create("album_review").should be_an_instance_of(MyApp::AlbumReviewSerializer)
+      expect(factory.create("album_review")).to be_an_instance_of(MyApp::AlbumReviewSerializer)
     end
+
     it "creates multi-word lowercase plural string" do
-      factory.create("album_reviews").should be_an_instance_of(MyApp::AlbumReviewSerializer)
+      expect(factory.create("album_reviews")).to be_an_instance_of(MyApp::AlbumReviewSerializer)
     end
+
     it "creates multi-word symbol" do
-      factory.create(:album_review).should be_an_instance_of(MyApp::AlbumReviewSerializer)
+      expect(factory.create(:album_review)).to be_an_instance_of(MyApp::AlbumReviewSerializer)
     end
+
     it "creates multi-word class" do
-      factory.create(MyApp::AlbumReview).should be_an_instance_of(MyApp::AlbumReviewSerializer)
+      expect(factory.create(MyApp::AlbumReview)).to be_an_instance_of(MyApp::AlbumReviewSerializer)
     end
   end
-
 end

--- a/spec/fixtures/db.rb
+++ b/spec/fixtures/db.rb
@@ -1,6 +1,6 @@
 require 'sqlite3'
 require 'active_record'
-require 'protected_attributes'
+require 'protected_attributes_continued'
 
 ActiveRecord::Base.establish_connection(
   :adapter => 'sqlite3',

--- a/spec/restpack_serializer_spec.rb
+++ b/spec/restpack_serializer_spec.rb
@@ -6,8 +6,8 @@ describe RestPack::Serializer do
 
   context "#setup" do
     it "has defaults" do
-      subject.config.href_prefix.should == ''
-      subject.config.page_size.should == 10
+      expect(subject.config.href_prefix).to eq('')
+      expect(subject.config.page_size).to eq(10)
     end
 
     it "can be configured" do
@@ -16,8 +16,8 @@ describe RestPack::Serializer do
         config.page_size = 50
       end
 
-      subject.config.href_prefix.should == '/api/v1'
-      subject.config.page_size.should == 50
+      expect(subject.config.href_prefix).to eq('/api/v1')
+      expect(subject.config.page_size).to eq(50)
     end
   end
 end

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -3,18 +3,19 @@ require 'spec_helper'
 describe RestPack::Serializer::Result do
   context 'a new instance' do
     it 'has defaults' do
-      subject.resources.should == {}
-      subject.meta.should == {}
-      subject.links.should == {}
+      expect(subject.resources).to eq({})
+      expect(subject.meta).to eq({})
+      expect(subject.links).to eq({})
     end
   end
 
   context 'when serializing' do
     let(:result) { subject.serialize }
+
     context 'in jsonapi.org format' do
       context 'an empty result' do
         it 'returns an empty result' do
-          result.should == {}
+          expect(result).to eq({})
         end
       end
 
@@ -26,9 +27,9 @@ describe RestPack::Serializer::Result do
         end
 
         it 'returns correct jsonapi.org format' do
-          result[:albums].should == subject.resources[:albums]
-          result[:meta].should == subject.meta
-          result[:links].should == subject.links
+          expect(result[:albums]).to eq(subject.resources[:albums])
+          expect(result[:meta]).to eq(subject.meta)
+          expect(result[:links]).to eq(subject.links)
         end
       end
 
@@ -43,16 +44,16 @@ describe RestPack::Serializer::Result do
         end
 
         it 'returns correct jsonapi.org format, including injected has_many links' do
-          result[:albums].should == [{ id: '1', name: 'AMOK', links: { songs: ['91'] } }]
-          result[:links].should == subject.links
-          result[:linked][:songs].should == subject.resources[:songs]
+          expect(result[:albums]).to eq([{ id: '1', name: 'AMOK', links: { songs: ['91'] } }])
+          expect(result[:links]).to eq(subject.links)
+          expect(result[:linked][:songs]).to eq(subject.resources[:songs])
         end
 
         it 'includes resources in correct order' do
-          result.keys[0].should == :albums
-          result.keys[1].should == :linked
-          result.keys[2].should == :links
-          result.keys[3].should == :meta
+          expect(result.keys[0]).to eq(:albums)
+          expect(result.keys[1]).to eq(:linked)
+          expect(result.keys[2]).to eq(:links)
+          expect(result.keys[3]).to eq(:meta)
         end
 
         context 'with multiple calls to serialize' do
@@ -62,7 +63,7 @@ describe RestPack::Serializer::Result do
           end
 
           it 'does not create duplicate has_many links' do
-            result[:albums].first[:links][:songs].count.should == 1
+            expect(result[:albums].first[:links][:songs].count).to eq(1)
           end
         end
       end

--- a/spec/serializable/filterable_spec.rb
+++ b/spec/serializable/filterable_spec.rb
@@ -9,6 +9,6 @@ describe RestPack::Serializer::Filterable do
   end
 
   it "captures the specified filters" do
-    CustomSerializer.serializable_filters.should == [:a, :c]
+    expect(CustomSerializer.serializable_filters).to eq([:a, :c])
   end
 end

--- a/spec/serializable/options_spec.rb
+++ b/spec/serializable/options_spec.rb
@@ -6,94 +6,99 @@ describe RestPack::Serializer::Options do
   let(:scope) { nil }
 
   describe 'default values' do
-    it { subject.model_class.should == MyApp::Song }
-    it { subject.include.should == [] }
-    it { subject.page.should == 1 }
-    it { subject.page_size.should == 10 }
-    it { subject.filters.should == {} }
-    it { subject.scope.should == MyApp::Song.all }
-    it { subject.default_page_size?.should == true }
-    it { subject.filters_as_url_params.should == '' }
+    it { expect(subject.model_class).to eq(MyApp::Song) }
+    it { expect(subject.include).to eq([]) }
+    it { expect(subject.page).to eq(1) }
+    it { expect(subject.page_size).to eq(10) }
+    it { expect(subject.filters).to eq({}) }
+    it { expect(subject.scope).to eq(MyApp::Song.all) }
+    it { expect(subject.default_page_size?).to eq(true) }
+    it { expect(subject.filters_as_url_params).to eq('') }
   end
 
   describe 'with paging params' do
     let(:params) { { 'page' => '2', 'page_size' => '8' } }
-    it { subject.page.should == 2 }
-    it { subject.page_size.should == 8 }
+    it { expect(subject.page).to eq(2) }
+    it { expect(subject.page_size).to eq(8) }
   end
 
   describe 'with include' do
     let(:params) { { 'include' => 'model1,model2' } }
-    it { subject.include.should == ["model1", "model2"] }
+    it { expect(subject.include).to eq(%w(model1 model2)) }
   end
 
   context 'with filters' do
     describe 'with no filter params' do
-      let(:params) { { } }
-      it { subject.filters.should == {} }
+      let(:params) { {} }
+      it { expect(subject.filters).to eq({}) }
     end
+
     describe 'with a primary key with a single value' do
       let(:params) { { 'id' => '142857' } }
-      it { subject.filters.should == { id: ['142857'] } }
-      it { subject.filters_as_url_params.should == 'id=142857' }
+      it { expect(subject.filters).to eq(id: %w(142857)) }
+      it { expect(subject.filters_as_url_params).to eq('id=142857') }
     end
+
     describe 'with a primary key with multiple values' do
       let(:params) { { 'ids' => '42,142857' } }
-      it { subject.filters.should == { id: ['42', '142857'] } }
-      it { subject.filters_as_url_params.should == 'id=42,142857' }
+      it { expect(subject.filters).to eq(id: %w(42 142857)) }
+      it { expect(subject.filters_as_url_params).to eq('id=42,142857') }
     end
+
     describe 'with a foreign key with a single value' do
       let(:params) { { 'album_id' => '789' } }
-      it { subject.filters.should == { album_id: ['789'] } }
-      it { subject.filters_as_url_params.should == 'album_id=789' }
+      it { expect(subject.filters).to eq(album_id: %w(789)) }
+      it { expect(subject.filters_as_url_params).to eq('album_id=789') }
     end
+
     describe 'with a foreign key with multiple values' do
       let(:params) { { 'album_id' => '789,678,567' } }
-      it { subject.filters.should == { album_id: ['789', '678', '567'] } }
-      it { subject.filters_as_url_params.should == 'album_id=789,678,567' }
+      it { expect(subject.filters).to eq(album_id: %w(789 678 567)) }
+      it { expect(subject.filters_as_url_params).to eq('album_id=789,678,567') }
     end
+
     describe 'with multiple foreign keys' do
       let(:params) { { 'album_id' => '111,222', 'artist_id' => '888,999' } }
-      it { subject.filters.should == { album_id: ['111', '222'], artist_id: ['888', '999'] } }
-      it { subject.filters_as_url_params.should == 'album_id=111,222&artist_id=888,999' }
+      it { expect(subject.filters).to eq(album_id: %w(111 222), artist_id: %w(888 999)) }
+      it { expect(subject.filters_as_url_params).to eq('album_id=111,222&artist_id=888,999') }
     end
   end
 
   context 'with sorting parameters' do
     describe 'with no params' do
-      let(:params) { { } }
-      it { subject.sorting.should == {} }
+      let(:params) { {} }
+      it { expect(subject.sorting).to eq({}) }
     end
     describe 'with a sorting value' do
       let(:params) { { 'sort' => 'Title' } }
-      it { subject.sorting.should == { title: :asc } }
-      it { subject.sorting_as_url_params.should == 'sort=title' }
+      it { expect(subject.sorting).to eq(title: :asc) }
+      it { expect(subject.sorting_as_url_params).to eq('sort=title') }
     end
     describe 'with a descending sorting value' do
       let(:params) { { 'sort' => '-title' } }
-      it { subject.sorting.should == { title: :desc } }
-      it { subject.sorting_as_url_params.should == 'sort=-title' }
+      it { expect(subject.sorting).to eq(title: :desc) }
+      it { expect(subject.sorting_as_url_params).to eq('sort=-title') }
     end
     describe 'with multiple sorting values' do
       let(:params) { { 'sort' => '-Title,ID' } }
-      it { subject.sorting.should == { title: :desc, id: :asc } }
-      it { subject.sorting_as_url_params.should == 'sort=-title,id' }
+      it { expect(subject.sorting).to eq(title: :desc, id: :asc) }
+      it { expect(subject.sorting_as_url_params).to eq('sort=-title,id') }
     end
     describe 'with a not allowed sorting value' do
       let(:params) { { 'sort' => '-title,album_id,id' } }
-      it { subject.sorting.should == { title: :desc, id: :asc } }
-      it { subject.sorting_as_url_params.should == 'sort=-title,id' }
+      it { expect(subject.sorting).to eq(title: :desc, id: :asc) }
+      it { expect(subject.sorting_as_url_params).to eq('sort=-title,id') }
     end
   end
 
   context 'scopes' do
     describe 'with default scope' do
-      it { subject.scope.should == MyApp::Song.all }
+      it { expect(subject.scope).to eq(MyApp::Song.all) }
     end
 
     describe 'with custom scope' do
       let(:scope) { MyApp::Song.where("id >= 100") }
-      it { subject.scope.should == scope }
+      it { expect(subject.scope).to eq(scope) }
     end
   end
 end

--- a/spec/serializable/paging_spec.rb
+++ b/spec/serializable/paging_spec.rb
@@ -8,32 +8,35 @@ describe RestPack::Serializer::Paging do
 
   context "#page" do
     let(:page) { MyApp::SongSerializer.page(params, scope, context) }
-    let(:params) { { } }
+    let(:params) { {} }
     let(:scope) { nil }
-    let(:context) { { } }
+    let(:context) { {} }
 
     context "with defaults" do
       it "page defaults to 1" do
-        page[:meta][:songs][:page].should == 1
+        expect(page[:meta][:songs][:page]).to eq(1)
       end
+
       it "page_size defaults to 10" do
-        page[:meta][:songs][:page_size].should == 10
+        expect(page[:meta][:songs][:page_size]).to eq(10)
       end
+
       it "includes valid paging meta data" do
-        page[:meta][:songs][:count].should == 18
-        page[:meta][:songs][:page_count].should == 2
-        page[:meta][:songs][:first_href].should == '/songs'
-        page[:meta][:songs][:previous_page].should == nil
-        page[:meta][:songs][:previous_href].should == nil
-        page[:meta][:songs][:next_page].should == 2
-        page[:meta][:songs][:next_href].should == '/songs?page=2'
-        page[:meta][:songs][:last_href].should == '/songs?page=2'
+        expect(page[:meta][:songs][:count]).to eq(18)
+        expect(page[:meta][:songs][:page_count]).to eq(2)
+        expect(page[:meta][:songs][:first_href]).to eq('/songs')
+        expect(page[:meta][:songs][:previous_page]).to eq(nil)
+        expect(page[:meta][:songs][:previous_href]).to eq(nil)
+        expect(page[:meta][:songs][:next_page]).to eq(2)
+        expect(page[:meta][:songs][:next_href]).to eq('/songs?page=2')
+        expect(page[:meta][:songs][:last_href]).to eq('/songs?page=2')
       end
+
       it "includes links" do
-        page[:links].should == {
-          'songs.album' => { :href => "/albums/{songs.album}", :type => :albums },
-          'songs.artist' => { :href => "/artists/{songs.artist}", :type => :artists }
-        }
+        expect(page[:links]).to eq(
+          'songs.album' => { href: "/albums/{songs.album}", type: :albums },
+          'songs.artist' => { href: "/artists/{songs.artist}", type: :artists }
+        )
       end
     end
 
@@ -42,42 +45,44 @@ describe RestPack::Serializer::Paging do
         @original_prefix = MyApp::SongSerializer.href_prefix
         MyApp::SongSerializer.href_prefix = '/api/v3'
       end
-      after do
-        MyApp::SongSerializer.href_prefix = @original_prefix
-      end
-      let(:page) do
-        MyApp::SongSerializer.page(params, scope, context)
-      end
+      after { MyApp::SongSerializer.href_prefix = @original_prefix }
+
+      let(:page) { MyApp::SongSerializer.page(params, scope, context) }
+
       it 'should use prefixed links' do
-        page[:meta][:songs][:next_href].should == '/api/v3/songs?page=2'
+        expect(page[:meta][:songs][:next_href]).to eq('/api/v3/songs?page=2')
       end
     end
 
     context "with custom page size" do
       let(:params) { { page_size: '3' } }
+
       it "returns custom page sizes" do
-        page[:meta][:songs][:page_size].should == 3
-        page[:meta][:songs][:page_count].should == 6
+        expect(page[:meta][:songs][:page_size]).to eq(3)
+        expect(page[:meta][:songs][:page_count]).to eq(6)
       end
+
       it "includes the custom page size in the page hrefs" do
-        page[:meta][:songs][:next_page].should == 2
-        page[:meta][:songs][:next_href].should == '/songs?page=2&page_size=3'
-        page[:meta][:songs][:last_href].should == '/songs?page=6&page_size=3'
+        expect(page[:meta][:songs][:next_page]).to eq(2)
+        expect(page[:meta][:songs][:next_href]).to eq('/songs?page=2&page_size=3')
+        expect(page[:meta][:songs][:last_href]).to eq('/songs?page=6&page_size=3')
       end
     end
 
     context "with custom filter" do
       context "valid :title" do
         let(:params) { { title: @album1.songs[0].title } }
+
         it "returns the album" do
-          page[:meta][:songs][:count].should == 1
+          expect(page[:meta][:songs][:count]).to eq(1)
         end
       end
 
       context "invalid :title" do
         let(:params) { { title: "this doesn't exist" } }
+
         it "returns the album" do
-          page[:meta][:songs][:count].should == 0
+          expect(page[:meta][:songs][:count]).to eq(0)
         end
       end
     end
@@ -87,13 +92,13 @@ describe RestPack::Serializer::Paging do
 
       it "returns reversed titles" do
         first = MyApp::Song.first
-        page[:songs].first[:title].should == first.title.reverse
+        expect(page[:songs].first[:title]).to eq(first.title.reverse)
       end
     end
 
     it "serializes results" do
       first = MyApp::Song.first
-      page[:songs].first.should == {
+      expect(page[:songs].first).to eq(
         id: first.id.to_s,
         title: first.title,
         album_id: first.album_id,
@@ -101,17 +106,17 @@ describe RestPack::Serializer::Paging do
           album: first.album_id.to_s,
           artist: first.artist_id.to_s
         }
-      }
+      )
     end
 
     context "first page" do
       let(:params) { { page: '1' } }
 
       it "returns first page" do
-        page[:meta][:songs][:page].should == 1
-        page[:meta][:songs][:page_size].should == 10
-        page[:meta][:songs][:previous_page].should == nil
-        page[:meta][:songs][:next_page].should == 2
+        expect(page[:meta][:songs][:page]).to eq(1)
+        expect(page[:meta][:songs][:page_size]).to eq(10)
+        expect(page[:meta][:songs][:previous_page]).to eq(nil)
+        expect(page[:meta][:songs][:next_page]).to eq(2)
       end
     end
 
@@ -119,11 +124,11 @@ describe RestPack::Serializer::Paging do
       let(:params) { { page: '2' } }
 
       it "returns second page" do
-        page[:songs].length.should == 8
-        page[:meta][:songs][:page].should == 2
-        page[:meta][:songs][:previous_page].should == 1
-        page[:meta][:songs][:next_page].should == nil
-        page[:meta][:songs][:previous_href].should == '/songs'
+        expect(page[:songs].length).to eq(8)
+        expect(page[:meta][:songs][:page]).to eq(2)
+        expect(page[:meta][:songs][:previous_page]).to eq(1)
+        expect(page[:meta][:songs][:next_page]).to eq(nil)
+        expect(page[:meta][:songs][:previous_href]).to eq('/songs')
       end
     end
 
@@ -131,48 +136,49 @@ describe RestPack::Serializer::Paging do
       let(:params) { { include: 'albums' } }
 
       it "includes side-loaded models" do
-        page[:linked][:albums].should_not == nil
+        expect(page[:linked][:albums]).not_to eq(nil)
       end
 
       it "includes the side-loads in the main meta data" do
-        page[:meta][:songs][:include].should == ["albums"]
+        expect(page[:meta][:songs][:include]).to eq(%w(albums))
       end
 
       it "includes the side-loads in page hrefs" do
-        page[:meta][:songs][:next_href].should == '/songs?page=2&include=albums'
+        expect(page[:meta][:songs][:next_href]).to eq('/songs?page=2&include=albums')
       end
 
       it "includes links between documents" do
         song = page[:songs].first
         song_model = MyApp::Song.find(song[:id])
-        song[:links][:album].should == song_model.album_id.to_s
-        song[:links][:artist].should == song_model.artist_id.to_s
+        expect(song[:links][:album]).to eq(song_model.album_id.to_s)
+        expect(song[:links][:artist]).to eq(song_model.artist_id.to_s)
 
         album = page[:linked][:albums].first
         album_model = MyApp::Album.find(album[:id])
 
-        album[:links][:artist].should == album_model.artist_id.to_s
-        (page[:songs].map { |song| song[:id] } - album[:links][:songs]).empty?.should be_truthy
+        expect(album[:links][:artist]).to eq(album_model.artist_id.to_s)
+        expect((page[:songs].map { |song| song[:id] } - album[:links][:songs]).empty?).to eq(true)
       end
 
       context "with includes as comma delimited string" do
         let(:params) { { include: "albums,artists" } }
+
         it "includes side-loaded models" do
-          page[:linked][:albums].should_not == nil
-          page[:linked][:artists].should_not == nil
+          expect(page[:linked][:albums]).not_to eq(nil)
+          expect(page[:linked][:artists]).not_to eq(nil)
         end
 
         it "includes the side-loads in page hrefs" do
-          page[:meta][:songs][:next_href].should == '/songs?page=2&include=albums,artists'
+          expect(page[:meta][:songs][:next_href]).to eq('/songs?page=2&include=albums,artists')
         end
 
         it "includes links" do
-          page[:links]['songs.album'].should_not == nil
-          page[:links]['songs.artist'].should_not == nil
-          page[:links]['albums.songs'].should_not == nil
-          page[:links]['albums.artist'].should_not == nil
-          page[:links]['artists.songs'].should_not == nil
-          page[:links]['artists.albums'].should_not == nil
+          expect(page[:links]['songs.album']).not_to eq(nil)
+          expect(page[:links]['songs.artist']).not_to eq(nil)
+          expect(page[:links]['albums.songs']).not_to eq(nil)
+          expect(page[:links]['albums.artist']).not_to eq(nil)
+          expect(page[:links]['artists.songs']).not_to eq(nil)
+          expect(page[:links]['artists.albums']).not_to eq(nil)
         end
       end
     end
@@ -182,7 +188,7 @@ describe RestPack::Serializer::Paging do
         let(:params) { {} }
 
         it "returns a page of all data" do
-          page[:meta][:songs][:count].should == 18
+          expect(page[:meta][:songs][:count]).to eq(18)
         end
       end
 
@@ -190,11 +196,11 @@ describe RestPack::Serializer::Paging do
         let(:params) { { album_id: @album1.id.to_s } }
 
         it "returns a page with songs from album1" do
-          page[:meta][:songs][:count].should == @album1.songs.length
+          expect(page[:meta][:songs][:count]).to eq(@album1.songs.length)
         end
 
         it "includes the filter in page hrefs" do
-          page[:meta][:songs][:next_href].should == "/songs?page=2&album_id=#{@album1.id}"
+          expect(page[:meta][:songs][:next_href]).to eq("/songs?page=2&album_id=#{@album1.id}")
         end
       end
     end
@@ -204,7 +210,7 @@ describe RestPack::Serializer::Paging do
         let(:params) { {} }
 
         it "uses the model's sorting" do
-          page[:songs].first[:id].to_i.should < page[:songs].last[:id].to_i
+          expect(page[:songs].first[:id].to_i < page[:songs].last[:id].to_i).to eq(true)
         end
       end
 
@@ -212,11 +218,11 @@ describe RestPack::Serializer::Paging do
         let(:params) { { sort: '-title' } }
 
         it 'returns a page with sorted songs' do
-          page[:songs].first[:title].should > page[:songs].last[:title]
+          expect(page[:songs].first[:title] > page[:songs].last[:title]).to eq(true)
         end
 
         it 'includes the sorting in page hrefs' do
-          page[:meta][:songs][:next_href].should == '/songs?page=2&sort=-title'
+          expect(page[:meta][:songs][:next_href]).to eq('/songs?page=2&sort=-title')
         end
       end
     end
@@ -230,7 +236,7 @@ describe RestPack::Serializer::Paging do
       let(:scope) { MyApp::Album.classic }
 
       it "returns a page of scoped data" do
-        page[:meta][:albums][:count].should == 2
+        expect(page[:meta][:albums][:count]).to eq(2)
       end
     end
   end
@@ -242,43 +248,44 @@ describe RestPack::Serializer::Paging do
 
     context "with defaults" do
       it "includes valid paging meta data" do
-        page[:meta][:songs][:count].should == 18
-        page[:meta][:songs][:page_count].should == 2
-        page[:meta][:songs][:previous_page].should == nil
-        page[:meta][:songs][:next_page].should == 2
+        expect(page[:meta][:songs][:count]).to eq(18)
+        expect(page[:meta][:songs][:page_count]).to eq(2)
+        expect(page[:meta][:songs][:previous_page]).to eq(nil)
+        expect(page[:meta][:songs][:next_page]).to eq(2)
       end
     end
 
     context "with custom page size" do
       let(:params) { { page_size: '3' } }
+
       it "returns custom page sizes" do
-        page[:meta][:songs][:page_size].should == 3
-        page[:meta][:songs][:page_count].should == 6
+        expect(page[:meta][:songs][:page_size]).to eq(3)
+        expect(page[:meta][:songs][:page_count]).to eq(6)
       end
     end
   end
 
   context "paging with paged side-load" do
     let(:page) { MyApp::AlbumSerializer.page_with_options(options) }
-    let(:options) { RestPack::Serializer::Options.new(MyApp::AlbumSerializer, { include: 'songs' }) }
+    let(:options) { RestPack::Serializer::Options.new(MyApp::AlbumSerializer, include: 'songs') }
 
     it "includes side-loaded paging data in meta data" do
-      page[:meta][:albums].should_not == nil
-      page[:meta][:albums][:page].should == 1
-      page[:meta][:songs].should_not == nil
-      page[:meta][:songs][:page].should == 1
+      expect(page[:meta][:albums]).not_to eq(nil)
+      expect(page[:meta][:albums][:page]).to eq(1)
+      expect(page[:meta][:songs]).not_to eq(nil)
+      expect(page[:meta][:songs][:page]).to eq(1)
     end
   end
 
   context "paging with two paged side-loads" do
     let(:page) { MyApp::ArtistSerializer.page_with_options(options) }
-    let(:options) { RestPack::Serializer::Options.new(MyApp::ArtistSerializer, { include: 'albums,songs' }) }
+    let(:options) { RestPack::Serializer::Options.new(MyApp::ArtistSerializer, include: 'albums,songs') }
 
     it "includes side-loaded paging data in meta data" do
-      page[:meta][:albums].should_not == nil
-      page[:meta][:albums][:page].should == 1
-      page[:meta][:songs].should_not == nil
-      page[:meta][:songs][:page].should == 1
+      expect(page[:meta][:albums]).not_to eq(nil)
+      expect(page[:meta][:albums][:page]).to eq(1)
+      expect(page[:meta][:songs]).not_to eq(nil)
+      expect(page[:meta][:songs][:page]).to eq(1)
     end
   end
 end

--- a/spec/serializable/resource_spec.rb
+++ b/spec/serializable/resource_spec.rb
@@ -9,18 +9,18 @@ describe RestPack::Serializer::Resource do
   let(:resource) { MyApp::SongSerializer.resource(params, scope, context) }
   let(:params) { { id: @song.id } }
   let(:scope) { nil }
-  let(:context) { { } }
+  let(:context) { {} }
 
   it "returns a resource by id" do
-    resource[:songs].count.should == 1
-    resource[:songs][0][:id].should == @song.id.to_s
+    expect(resource[:songs].count).to eq(1)
+    expect(resource[:songs][0][:id]).to eq(@song.id.to_s)
   end
 
   context "with context" do
     let(:context) { { reverse_title?: true } }
 
     it "returns reversed titles" do
-      resource[:songs][0][:title].should == @song.title.reverse
+      expect(resource[:songs][0][:title]).to eq(@song.title.reverse)
     end
   end
 
@@ -28,19 +28,20 @@ describe RestPack::Serializer::Resource do
     let(:params) { { id: @song.id, include: 'albums' } }
 
     it "includes side-loaded models" do
-      resource[:linked][:albums].count.should == 1
-      resource[:linked][:albums].first[:id].should == @song.album.id.to_s
+      expect(resource[:linked][:albums].count).to eq(1)
+      expect(resource[:linked][:albums].first[:id]).to eq(@song.album.id.to_s)
     end
 
     it "includes the side-loads in the main meta data" do
-      resource[:meta][:songs][:include].should == ["albums"]
+      expect(resource[:meta][:songs][:include]).to eq(%w(albums))
     end
   end
 
   describe "missing resource" do
     let(:params) { { id: "-99" } }
+
     it "returns no resource" do
-      resource[:songs].length.should == 0
+      expect(resource[:songs].length).to eq(0)
     end
 
     #TODO: add specs for jsonapi error format when it has been standardised
@@ -49,11 +50,11 @@ describe RestPack::Serializer::Resource do
   end
 
   describe "song with no artist" do
-    let(:song) { FactoryGirl.create(:song, :artist => nil) }
+    let(:song) { FactoryGirl.create(:song, artist: nil) }
     let(:resource) { MyApp::SongSerializer.resource(id: song.id.to_s) }
 
     it "should not have an artist link" do
-      resource[:songs][0][:links].keys.should_not include(:artist)
+      expect(resource[:songs][0][:links].keys).not_to include(:artist)
     end
   end
 end

--- a/spec/serializable/serializer_spec.rb
+++ b/spec/serializable/serializer_spec.rb
@@ -27,7 +27,7 @@ describe RestPack::Serializer do
     end
 
     it ".as_json serializes to an empty hash" do
-      EmptySerializer.as_json(person).should == { }
+      expect(EmptySerializer.as_json(person)).to eq({})
     end
   end
 
@@ -71,11 +71,11 @@ describe RestPack::Serializer do
     end
 
     it ".as_json serializes" do
-      serialized = DerivedSerializer.as_json({}, { include_food?: false, name: 'Ben', age: 1 })
-      serialized.should == { #NOTE: I think this should include colour as DerivedSerializer defines it, but this would be a big breaking change
+      serialized = DerivedSerializer.as_json({}, include_food?: false, name: 'Ben', age: 1)
+      expect(serialized).to eq({ #NOTE: I think this should include colour as DerivedSerializer defines it, but this would be a big breaking change
         name: "Ben",
         age: 1
-      }
+      })
     end
   end
 
@@ -116,34 +116,35 @@ describe RestPack::Serializer do
 
     def custom_attributes
       {
-        :custom_key => "custom value for model id #{@model.id}"
+        custom_key: "custom value for model id #{@model.id}"
       }
     end
   end
 
   describe ".serialize" do
     it "serializes to an array" do
-      serializer.class.serialize(person).should == {
+      expect(serializer.class.serialize(person)).to eq(
         people: [{
           id: '123', name: 'Gavin', description: 'This is person #123',
           href: '/people/123', custom_key: 'custom value for model id 123'
         }]
-      }
+      )
     end
   end
 
   describe ".as_json" do
     it "serializes specified attributes" do
-      serializer.as_json(person).should == {
+      expect(serializer.as_json(person)).to eq(
         id: '123', name: 'Gavin', description: 'This is person #123',
         href: '/people/123', custom_key: 'custom value for model id 123'
-      }
+      )
     end
 
     context "an array" do
       let(:people) { [person, person] }
+
       it "results in a serialized array" do
-        serializer.as_json(people).should == [
+        expect(serializer.as_json(people)).to eq([
           {
             id: '123', name: 'Gavin', description: 'This is person #123',
             href: '/people/123', custom_key: 'custom value for model id 123'
@@ -152,11 +153,12 @@ describe RestPack::Serializer do
             id: '123', name: 'Gavin', description: 'This is person #123',
             href: '/people/123', custom_key: 'custom value for model id 123'
           }
-        ]
+        ])
       end
+
       context "#array_as_json" do
         it "results in a serialized array" do
-          serializer.class.array_as_json(people).should == [
+          expect(serializer.class.array_as_json(people)).to eq([
             {
               id: '123', name: 'Gavin', description: 'This is person #123',
               href: '/people/123', custom_key: 'custom value for model id 123'
@@ -165,75 +167,75 @@ describe RestPack::Serializer do
               id: '123', name: 'Gavin', description: 'This is person #123',
               href: '/people/123', custom_key: 'custom value for model id 123'
             }
-          ]
+          ])
         end
       end
     end
 
     context "nil" do
       it "results in nil" do
-        serializer.as_json(nil).should == nil
+        expect(serializer.as_json(nil)).to eq(nil)
       end
     end
 
     context "with options" do
       it "excludes specified attributes" do
-        serializer.as_json(person, { include_description?: false }).should == {
+        expect(serializer.as_json(person, include_description?: false)).to eq(
           id: '123', name: 'Gavin', href: '/people/123',
           custom_key: 'custom value for model id 123'
-        }
+        )
       end
 
       it "excludes custom attributes if specified" do
-        hash = serializer.as_json(person, { is_admin?: false })
-        hash[:admin_info].should == nil
+        hash = serializer.as_json(person, is_admin?: false)
+        expect(hash[:admin_info]).to eq(nil)
       end
 
       it "includes custom attributes if specified" do
-        hash = serializer.as_json(person, { is_admin?: true })
-        hash[:admin_info].should == {
+        hash = serializer.as_json(person, is_admin?: true)
+        expect(hash[:admin_info]).to eq(
           key: "super_secret_sauce",
           array: [
             name: 'Alex'
           ]
-        }
+        )
       end
 
       it "excludes a blacklist of attributes if specified as an array" do
-        serializer.as_json(person, { attribute_blacklist: [:name, :description] }).should == {
+        expect(serializer.as_json(person, attribute_blacklist: [:name, :description])).to eq(
           id: '123',
           href: '/people/123',
           custom_key: 'custom value for model id 123'
-        }
+        )
       end
 
       it "excludes a blacklist of attributes if specified as a string" do
-        serializer.as_json(person, { attribute_blacklist: 'name, description' }).should == {
+        expect(serializer.as_json(person, attribute_blacklist: 'name, description')).to eq(
           id: '123',
           href: '/people/123',
           custom_key: 'custom value for model id 123'
-        }
+        )
       end
 
       it "includes a whitelist of attributes if specified as an array" do
-        serializer.as_json(person, { attribute_whitelist: [:name, :description] }).should == {
+        expect(serializer.as_json(person, attribute_whitelist: [:name, :description])).to eq(
           name: 'Gavin',
           description: 'This is person #123',
           custom_key: 'custom value for model id 123'
-        }
+        )
       end
 
       it "includes a whitelist of attributes if specified as a string" do
-        serializer.as_json(person, { attribute_whitelist: 'name, description' }).should == {
+        expect(serializer.as_json(person, attribute_whitelist: 'name, description')).to eq(
           name: 'Gavin',
           description: 'This is person #123',
           custom_key: 'custom value for model id 123'
-        }
+        )
       end
 
       it "raises an exception if both the whitelist and blacklist are provided" do
         expect do
-          serializer.as_json(person, { attribute_whitelist: [:name], attribute_blacklist: [:id] })
+          serializer.as_json(person, attribute_whitelist: [:name], attribute_blacklist: [:id])
         end.to raise_error(ArgumentError, "the context can't define both an `attribute_whitelist` and an `attribute_blacklist`")
       end
     end
@@ -245,10 +247,10 @@ describe RestPack::Serializer do
         it "includes 'links' data for :belongs_to associations" do
           @album1 = FactoryGirl.create(:album_with_songs, song_count: 11)
           json = serializer.as_json(@album1.songs.first)
-          json[:links].should == {
+          expect(json[:links]).to eq(
             artist: @album1.artist_id.to_s,
             album: @album1.id.to_s
-          }
+          )
         end
       end
 
@@ -256,12 +258,13 @@ describe RestPack::Serializer do
         let(:artist_factory) { FactoryGirl.create :artist_with_fans }
         let(:artist_serializer) { MyApp::ArtistSerializer.new }
         let(:json) { artist_serializer.as_json(artist_factory) }
-        let(:side_load_ids) { artist_has_association.map {|obj| obj.id.to_s } }
+        let(:side_load_ids) { artist_has_association.map { |obj| obj.id.to_s } }
 
         context "when the association has been eager loaded" do
           before do
-            artist_factory.fans.stub(:loaded?) { true }
+            allow(artist_factory.fans).to receive(:loaded?).and_return(true)
           end
+
           it "does not make a query to retrieve id values" do
             expect(artist_factory.fans).not_to receive(:pluck)
             json
@@ -291,7 +294,7 @@ describe RestPack::Serializer do
 
   describe "#model_class" do
     it "extracts the Model name from the Serializer name" do
-      PersonSerializer.model_class.should == Person
+      expect(PersonSerializer.model_class).to eq(Person)
     end
 
     context "with namespaced model class" do
@@ -306,7 +309,7 @@ describe RestPack::Serializer do
       end
 
       it "returns the correct class" do
-        NamespacedSerializer.model_class.should == SomeNamespace::Model
+        expect(NamespacedSerializer.model_class).to eq(SomeNamespace::Model)
       end
     end
   end
@@ -314,15 +317,15 @@ describe RestPack::Serializer do
   describe "#key" do
     context "with default key" do
       it "returns the correct key" do
-        PersonSerializer.key.should == :people
+        expect(PersonSerializer.key).to eq(:people)
       end
 
       it "has correct #singular_key" do
-        PersonSerializer.singular_key.should == :person
+        expect(PersonSerializer.singular_key).to eq(:person)
       end
 
       it "has correct #plural_key" do
-        PersonSerializer.plural_key.should == :people
+        expect(PersonSerializer.plural_key).to eq(:people)
       end
     end
 
@@ -333,11 +336,11 @@ describe RestPack::Serializer do
       end
 
       it "returns the correct key" do
-        SerializerWithCustomKey.key.should == :customers
+        expect(SerializerWithCustomKey.key).to eq(:customers)
       end
 
       it "has correct #singular_key" do
-        SerializerWithCustomKey.singular_key.should == :customer
+        expect(SerializerWithCustomKey.singular_key).to eq(:customer)
       end
     end
   end

--- a/spec/serializable/side_loading/belongs_to_spec.rb
+++ b/spec/serializable/side_loading/belongs_to_spec.rb
@@ -17,15 +17,15 @@ describe RestPack::Serializer::SideLoading do
           let(:options) { RestPack::Serializer::Options.new(MyApp::SongSerializer) }
 
           it "returns a hash with no data" do
-            side_loads.should == { :meta => {} }
+            expect(side_loads).to eq(meta: {})
           end
         end
 
         context "when including :albums" do
-          let(:options) { RestPack::Serializer::Options.new(MyApp::SongSerializer, { "include" => "albums" }) }
+          let(:options) { RestPack::Serializer::Options.new(MyApp::SongSerializer, "include" => "albums") }
 
           it "returns a hash with no data" do
-            side_loads.should == { :meta => {} }
+            expect(side_loads).to eq(meta: {})
           end
         end
       end
@@ -34,13 +34,13 @@ describe RestPack::Serializer::SideLoading do
         let(:models) { [MyApp::Song.first] }
 
         context "when including :albums" do
-          let(:options) { RestPack::Serializer::Options.new(MyApp::SongSerializer, { "include" => "albums" }) }
+          let(:options) { RestPack::Serializer::Options.new(MyApp::SongSerializer, "include" => "albums") }
 
           it "returns side-loaded albums" do
-            side_loads.should == {
+            expect(side_loads).to eq(
               albums: [MyApp::AlbumSerializer.as_json(MyApp::Song.first.album)],
-              meta: { }
-            }
+              meta: {}
+            )
           end
         end
       end
@@ -53,16 +53,16 @@ describe RestPack::Serializer::SideLoading do
         let(:models) { [song1, song2] }
 
         context "when including :albums" do
-          let(:options) { RestPack::Serializer::Options.new(MyApp::SongSerializer, { "include" => "albums" }) }
+          let(:options) { RestPack::Serializer::Options.new(MyApp::SongSerializer, "include" => "albums") }
 
           it "returns side-loaded albums" do
-            side_loads.should == {
+            expect(side_loads).to eq(
               albums: [
                 MyApp::AlbumSerializer.as_json(song1.album),
                 MyApp::AlbumSerializer.as_json(song2.album)
               ],
-              :meta => { }
-            }
+              meta: {}
+            )
           end
         end
       end
@@ -72,10 +72,13 @@ describe RestPack::Serializer::SideLoading do
         let(:models) { [b_side] }
 
         context 'when including :albums' do
-          let(:options) { RestPack::Serializer::Options.new(MyApp::SongSerializer, { "include" => "albums" }) }
+          let(:options) { RestPack::Serializer::Options.new(MyApp::SongSerializer, "include" => "albums") }
 
           it 'return a hash with no data' do
-            side_loads.should == { :meta => {}, :albums => [] }
+            expect(side_loads).to eq(
+              albums: [],
+              meta: {}
+            )
           end
         end
       end

--- a/spec/serializable/side_loading/has_and_belongs_many_spec.rb
+++ b/spec/serializable/side_loading/has_and_belongs_many_spec.rb
@@ -15,13 +15,13 @@ describe RestPack::Serializer::SideLoading do
         let(:models) { [@artist1] }
 
         context "when including :albums" do
-          let(:options) { RestPack::Serializer::Options.new(MyApp::ArtistSerializer, { "include" => "stalkers" }) }
+          let(:options) { RestPack::Serializer::Options.new(MyApp::ArtistSerializer, "include" => "stalkers") }
           let(:stalker_count) { @artist1.stalkers.count }
 
           it "returns side-loaded albums" do
-            side_loads[:stalkers].count.should == stalker_count
-            side_loads[:meta][:stalkers][:page].should == 1
-            side_loads[:meta][:stalkers][:count].should == stalker_count
+            expect(side_loads[:stalkers].count).to eq(stalker_count)
+            expect(side_loads[:meta][:stalkers][:page]).to eq(1)
+            expect(side_loads[:meta][:stalkers][:count]).to eq(stalker_count)
           end
         end
       end
@@ -30,12 +30,12 @@ describe RestPack::Serializer::SideLoading do
         let(:models) { [@artist1, @artist2] }
 
         context "when including :albums" do
-          let(:options) { RestPack::Serializer::Options.new(MyApp::ArtistSerializer, { "include" => "stalkers" }) }
+          let(:options) { RestPack::Serializer::Options.new(MyApp::ArtistSerializer, "include" => "stalkers") }
           let(:stalker_count) { @artist1.stalkers.count + @artist2.stalkers.count }
 
           it "returns side-loaded albums" do
-            side_loads[:stalkers].count.should == stalker_count
-            side_loads[:meta][:stalkers][:count].should == stalker_count
+            expect(side_loads[:stalkers].count).to eq(stalker_count)
+            expect(side_loads[:meta][:stalkers][:count]).to eq(stalker_count)
           end
         end
       end

--- a/spec/serializable/side_loading/has_many_spec.rb
+++ b/spec/serializable/side_loading/has_many_spec.rb
@@ -15,12 +15,12 @@ describe RestPack::Serializer::SideLoading do
         let(:models) { [@artist1] }
 
         context "when including :albums" do
-          let(:options) { RestPack::Serializer::Options.new(MyApp::ArtistSerializer, { "include" => "albums" }) }
+          let(:options) { RestPack::Serializer::Options.new(MyApp::ArtistSerializer, "include" => "albums") }
 
           it "returns side-loaded albums" do
-            side_loads[:albums].count.should == @artist1.albums.count
-            side_loads[:meta][:albums][:page].should == 1
-            side_loads[:meta][:albums][:count].should == @artist1.albums.count
+            expect(side_loads[:albums].count).to eq(@artist1.albums.count)
+            expect(side_loads[:meta][:albums][:page]).to eq(1)
+            expect(side_loads[:meta][:albums][:count]).to eq(@artist1.albums.count)
           end
         end
       end
@@ -29,12 +29,12 @@ describe RestPack::Serializer::SideLoading do
         let(:models) { [@artist1, @artist2] }
 
         context "when including :albums" do
-          let(:options) { RestPack::Serializer::Options.new(MyApp::ArtistSerializer, { "include" => "albums" }) }
+          let(:options) { RestPack::Serializer::Options.new(MyApp::ArtistSerializer, "include" => "albums") }
 
           it "returns side-loaded albums" do
             expected_count = @artist1.albums.count + @artist2.albums.count
-            side_loads[:albums].count.should == expected_count
-            side_loads[:meta][:albums][:count].should == expected_count
+            expect(side_loads[:albums].count).to eq(expected_count)
+            expect(side_loads[:meta][:albums][:count]).to eq(expected_count)
           end
         end
       end
@@ -42,28 +42,27 @@ describe RestPack::Serializer::SideLoading do
 
     describe '.has_many through' do
       context 'when including :fans' do
-        let(:options) { RestPack::Serializer::Options.new(MyApp::ArtistSerializer, { "include" => "fans" }) }
-        let(:artist_1) {FactoryGirl.create :artist_with_fans}
-        let(:artist_2) {FactoryGirl.create :artist_with_fans}
+        let(:options) { RestPack::Serializer::Options.new(MyApp::ArtistSerializer, "include" => "fans") }
+        let(:artist_1) { FactoryGirl.create :artist_with_fans }
+        let(:artist_2) { FactoryGirl.create :artist_with_fans }
 
         context "with a single model" do
-          let(:models) {[artist_1]}
+          let(:models) { [artist_1] }
 
           it 'returns side-loaded fans' do
-            side_loads[:fans].count.should == artist_1.fans.count
-            side_loads[:meta][:fans][:page].should == 1
-            side_loads[:meta][:fans][:count].should == artist_1.fans.count
+            expect(side_loads[:fans].count).to eq(artist_1.fans.count)
+            expect(side_loads[:meta][:fans][:page]).to eq(1)
+            expect(side_loads[:meta][:fans][:count]).to eq(artist_1.fans.count)
           end
         end
         context "with a multiple models" do
-          let(:models) {[artist_1, artist_2]}
+          let(:models) { [artist_1, artist_2] }
 
           it 'returns side-loaded fans' do
-            expected_count = artist_1.fans.count  + artist_2.fans.count
-
-            side_loads[:fans].count.should == expected_count
-            side_loads[:meta][:fans][:page].should == 1
-            side_loads[:meta][:fans][:count].should == expected_count
+            expected_count = artist_1.fans.count + artist_2.fans.count
+            expect(side_loads[:fans].count).to eq(expected_count)
+            expect(side_loads[:meta][:fans][:page]).to eq(1)
+            expect(side_loads[:meta][:fans][:count]).to eq(expected_count)
           end
 
           context "when there are shared fans" do

--- a/spec/serializable/side_loading/side_loading_spec.rb
+++ b/spec/serializable/side_loading/side_loading_spec.rb
@@ -12,7 +12,7 @@ describe RestPack::Serializer::SideLoading do
         message = ":wrong is not a valid include for MyApp::Song"
 
         expect do
-          MyApp::SongSerializer.side_loads([MyApp::Song.first], RestPack::Serializer::Options.new(MyApp::SongSerializer, { "include" => "wrong" }))
+          MyApp::SongSerializer.side_loads([MyApp::Song.first], RestPack::Serializer::Options.new(MyApp::SongSerializer, "include" => "wrong"))
         end.to raise_error(exception, message)
       end
     end
@@ -24,7 +24,7 @@ describe RestPack::Serializer::SideLoading do
         message = ":payments is not a valid include for MyApp::Artist"
 
         expect do
-          MyApp::ArtistSerializer.side_loads([payment.artist], RestPack::Serializer::Options.new(MyApp::ArtistSerializer, { "include" => "payments" }))
+          MyApp::ArtistSerializer.side_loads([payment.artist], RestPack::Serializer::Options.new(MyApp::ArtistSerializer, "include" => "payments"))
         end.to raise_error(exception, message)
       end
     end
@@ -36,7 +36,7 @@ describe RestPack::Serializer::SideLoading do
       attributes :a, :b, :c
     end
     it "defaults to empty array" do
-      CustomSerializer.can_includes.should == []
+      expect(CustomSerializer.can_includes).to eq([])
     end
 
     it "allows includes to be specified" do
@@ -45,33 +45,35 @@ describe RestPack::Serializer::SideLoading do
         can_include :model2, :model3
       end
 
-      CustomSerializer.can_includes.should == [:model1, :model2, :model3]
+      expect(CustomSerializer.can_includes).to eq([:model1, :model2, :model3])
     end
   end
 
   describe "#links" do
-    MyApp::AlbumSerializer.links.should == {
-      "albums.artist" => {
-        :href => "/artists/{albums.artist}",
-        :type => :artists
-      },
-      "albums.songs" => {
-        :href => "/songs?album_id={albums.id}",
-        :type => :songs
-      }
-    }
+    it do
+      expect(MyApp::AlbumSerializer.links).to eq(
+        "albums.artist" => {
+          href: "/artists/{albums.artist}",
+          type: :artists
+        },
+        "albums.songs" => {
+          href: "/songs?album_id={albums.id}",
+          type: :songs
+        }
+      )
+    end
 
     it "applies custom RestPack::Serializer.config.href_prefix" do
       original = RestPack::Serializer.config.href_prefix
       RestPack::Serializer.config.href_prefix = "/api/v1"
-      MyApp::AlbumSerializer.links["albums.artist"][:href].should == "/api/v1/artists/{albums.artist}"
+      expect(MyApp::AlbumSerializer.links["albums.artist"][:href]).to eq("/api/v1/artists/{albums.artist}")
       RestPack::Serializer.config.href_prefix = original
     end
 
     it "applies custom serializer  href_prefix" do
       original = RestPack::Serializer.config.href_prefix
       MyApp::AlbumSerializer.href_prefix = '/api/v2'
-      MyApp::AlbumSerializer.links["albums.artist"][:href].should == "/api/v2/artists/{albums.artist}"
+      expect(MyApp::AlbumSerializer.links["albums.artist"][:href]).to eq("/api/v2/artists/{albums.artist}")
       MyApp::AlbumSerializer.href_prefix = original
     end
   end
@@ -79,17 +81,17 @@ describe RestPack::Serializer::SideLoading do
   describe "#filterable_by" do
     context "a model with no :belongs_to relations" do
       it "is filterable by :id only" do
-        MyApp::ArtistSerializer.filterable_by.should == [:id]
+        expect(MyApp::ArtistSerializer.filterable_by).to eq([:id])
       end
     end
     context "a model with a single :belongs_to relations" do
       it "is filterable by primary key and foreign keys" do
-        MyApp::AlbumSerializer.filterable_by.should =~ [:id, :artist_id, :year]
+        expect(MyApp::AlbumSerializer.filterable_by).to eq([:id, :artist_id, :year])
       end
     end
     context "a model with multiple :belongs_to relations" do
       it "is filterable by primary key and foreign keys" do
-        MyApp::SongSerializer.filterable_by.should =~ [:id, :artist_id, :album_id, :title]
+        expect(MyApp::SongSerializer.filterable_by).to eq([:id, :artist_id, :album_id, :title])
       end
     end
   end

--- a/spec/serializable/single_spec.rb
+++ b/spec/serializable/single_spec.rb
@@ -12,15 +12,15 @@ describe RestPack::Serializer::Single do
   let(:context) { { } }
 
   it "returns a resource by id" do
-    resource[:id].should == @song.id.to_s
-    resource[:title].should == @song.title
+    expect(resource[:id]).to eq(@song.id.to_s)
+    expect(resource[:title]).to eq(@song.title)
   end
 
   context "with context" do
     let(:context) { { reverse_title?: true } }
 
     it "returns reversed titles" do
-      resource[:title].should == @song.title.reverse
+      expect(resource[:title]).to eq(@song.title.reverse)
     end
   end
 
@@ -28,7 +28,7 @@ describe RestPack::Serializer::Single do
     let(:params) { { id: @song.id + 100 } }
 
     it "returns nil" do
-      resource.should == nil
+      expect(resource).to eq(nil)
     end
   end
 end

--- a/spec/serializable/sortable_spec.rb
+++ b/spec/serializable/sortable_spec.rb
@@ -9,6 +9,6 @@ describe RestPack::Serializer::Sortable do
   end
 
   it 'captures the specified sorting attributes' do
-    CustomSerializer.serializable_sorting_attributes.should == [:a, :c]
+    expect(CustomSerializer.serializable_sorting_attributes).to eq([:a, :c])
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ FactoryGirl.find_definitions
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
+  config.raise_errors_for_deprecations!
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/support/factory.rb
+++ b/spec/support/factory.rb
@@ -1,14 +1,12 @@
 require 'factory_girl'
 
 FactoryGirl.define do
-  factory :artist, :class => MyApp::Artist do
-    sequence(:name) {|n| "Artist ##{n}" }
-    sequence(:website) {|n| "http://website#{n}.com/" }
+  factory :artist, class: MyApp::Artist do
+    sequence(:name) { |n| "Artist ##{n}" }
+    sequence(:website) { |n| "http://website#{n}.com/" }
 
     factory :artist_with_albums do
-      ignore do
-        album_count 3
-      end
+      transient { album_count 3 }
 
       after(:create) do |artist, evaluator|
         create_list(:album_with_songs, evaluator.album_count, artist: artist)
@@ -16,33 +14,29 @@ FactoryGirl.define do
     end
 
     factory :artist_with_fans do
-      ignore do
-        fans_count 3
-      end
+      transient { fans_count 3 }
+
       after(:create) do |artist, evaluator|
         create_list(:payment, evaluator.fans_count, artist: artist)
       end
     end
 
     factory :artist_with_stalkers do
-      ignore do
-        stalker_count 2
-      end
+      transient { stalker_count 2 }
+
       after(:create) do |artist, evaluator|
-        create_list(:stalker, evaluator.stalker_count, artists: [ artist ])
+        create_list(:stalker, evaluator.stalker_count, artists: [artist])
       end
     end
   end
 
-  factory :album, :class => MyApp::Album do
-    sequence(:title) {|n| "Album ##{n}" }
-    sequence(:year) {|n| 1960 + n }
+  factory :album, class: MyApp::Album do
+    sequence(:title) { |n| "Album ##{n}" }
+    sequence(:year) { |n| 1960 + n }
     artist
 
     factory :album_with_songs do
-      ignore do
-        song_count 10
-      end
+      transient { song_count 10 }
 
       after(:create) do |album, evaluator|
         create_list(:song, evaluator.song_count, album: album, artist: album.artist)
@@ -50,23 +44,23 @@ FactoryGirl.define do
     end
   end
 
-  factory :song, :class => MyApp::Song do
-    sequence(:title) {|n| "Song ##{n}" }
+  factory :song, class: MyApp::Song do
+    sequence(:title) { |n| "Song ##{n}" }
     artist
     album
   end
 
-  factory :payment, :class => MyApp::Payment do
+  factory :payment, class: MyApp::Payment do
     amount 999
     artist
     fan
   end
 
-  factory :fan, :class => MyApp::Fan do
-    sequence(:name) {|n| "Fan ##{n}"}
+  factory :fan, class: MyApp::Fan do
+    sequence(:name) { |n| "Fan ##{n}" }
   end
 
-  factory :stalker, :class => MyApp::Stalker do
-    sequence(:name) {|n| "Stalker ##{n}"}
+  factory :stalker, class: MyApp::Stalker do
+    sequence(:name) { |n| "Stalker ##{n}" }
   end
 end


### PR DESCRIPTION
This disables the collection of ids for has_many relationships. As part of the serialization it's grabbing these ids. For very large collections this slows the queries down since we're getting large queries of order ids.
